### PR TITLE
Aby obnovení fungovalo i jinde než na severozápadním kvadrantu Země

### DIFF
--- a/loadData.js
+++ b/loadData.js
@@ -405,7 +405,7 @@ function applyStateString(state)
 	{
 		if (splitState[i].indexOf("map=") == 0)
 		{
-			var mapState = splitState[i].match(/[0-9\.]+/g);
+			var mapState = splitState[i].match(/-?[0-9\.]+/g);
 			mapObj.setView([+mapState[1], +mapState[2]], +mapState[0]);
 		}
 		else if (splitState[i].indexOf("datasets=") == 0)


### PR DESCRIPTION
Oprava načítání stavu, který na západní nebo jižní polokouli ztrácí znaménko.

(I když by IMHO byl lepší prostě split na to lomítko.)